### PR TITLE
Fix typo on root page

### DIFF
--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -7,7 +7,7 @@
   <%= csrf_meta_tags %>
 </head>
 <body>
-  <button><%= link_to 'Game Loby', games_path %></button>
+  <button><%= link_to 'Game Lobby', games_path %></button>
 
 <%= yield %>
 


### PR DESCRIPTION
Altered text on button to read "Lobby" instead of "Loby" :)
